### PR TITLE
chore: add require-linked-issue PR gate

### DIFF
--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -1,0 +1,8 @@
+name: Require Linked Issue
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  issue-gate:
+    uses: TrySpeed/reusable-workflow/.github/workflows/require-linked-issue.yml@latest
+    secrets: inherit


### PR DESCRIPTION
Adds the `require-issue.yml` caller (`@latest`) so PRs must link a `project-management` issue.

Also adds the gate file (and deploy workflows) to each deploy workflow's `paths-ignore` so merging this does NOT trigger a deploy.

Refs: TrySpeed/project-management#1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)