### PR TITLE
chore: self-contained issue-gate (public repo)

### DIFF
--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -4,5 +4,48 @@ on:
     types: [opened, edited, synchronize, reopened]
 jobs:
   issue-gate:
-    uses: TrySpeed/reusable-workflow/.github/workflows/require-linked-issue.yml@latest
-    secrets: inherit
+    name: "issue-gate / issue-gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate linked issue from central repo
+        uses: actions/github-script@v7
+        env:
+          ISSUE_ORG: TrySpeed
+          ISSUE_REPO: project-management
+          ALLOW_CLOSED: "true"
+        with:
+          github-token: ${{ secrets.ISSUE_GATE_TOKEN }}
+          script: |
+            const org = process.env.ISSUE_ORG;
+            const repo = process.env.ISSUE_REPO;
+            const allowClosed = process.env.ALLOW_CLOSED === 'true';
+            const pr = context.payload.pull_request;
+            if (!pr) { core.setFailed('Must be triggered by a pull_request event.'); return; }
+            const body = pr.body || '';
+            const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const o = esc(org), r = esc(repo);
+            const urlPattern = new RegExp(`github\\.com/${o}/${r}/issues/(\\d+)`, 'gi');
+            const shortPattern = new RegExp(`(?<![\\w/-])${o}/${r}#(\\d+)`, 'gi');
+            const nums = new Set([
+              ...[...body.matchAll(urlPattern)].map((m) => parseInt(m[1], 10)),
+              ...[...body.matchAll(shortPattern)].map((m) => parseInt(m[1], 10)),
+            ]);
+            if (nums.size === 0) { core.setFailed(`No linked issue from ${org}/${repo} found in the PR description.`); return; }
+            const failures = [];
+            for (const n of nums) {
+              try {
+                const { data } = await github.rest.issues.get({ owner: org, repo, issue_number: n });
+                if (data.pull_request) { failures.push(`#${n} is a pull request, not an issue.`); continue; }
+                if (!allowClosed && data.state === 'closed') { failures.push(`#${n} is closed.`); continue; }
+                core.info(`Verified ${org}/${repo}#${n}: "${data.title}" [${data.state}]`);
+              } catch (e) {
+                if (e.status === 404) failures.push(`#${n} does not exist in ${org}/${repo}.`);
+                else failures.push(`Could not verify #${n} (API error ${e.status || '?'}).`);
+              }
+            }
+            if (failures.length) { core.setFailed('Linked issue validation failed:\n- ' + failures.join('\n- ')); return; }
+            core.info(`All ${nums.size} linked issue(s) verified.`);


### PR DESCRIPTION
## **User description**
Replaces the gate caller with a self-contained version — this is a PUBLIC repo and can't call the private reusable-workflow. Same logic, uses ISSUE_GATE_TOKEN, job named to match the ruleset's `issue-gate / issue-gate` check.

Refs: TrySpeed/project-management#1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Check linked issues directly in this public repo**

### What Changed
- Pull requests now verify linked issues from the central project-management repo without relying on a private shared workflow.
- The check looks for issue links in the PR description and fails when no matching issue is found.
- It also rejects links to non-issue items or missing issues, and reports closed issues when they are not allowed.
- The check runs under the name expected by the repository ruleset so it can be enforced consistently.

### Impact
`✅ Fewer PRs without a linked issue`
`✅ Clearer issue-link validation on pull requests`
`✅ Reliable ruleset checks in a public repository`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal pull request validation workflow to improve code review processes. No end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->